### PR TITLE
Final improvements

### DIFF
--- a/Year #2/First Half/CENG 211/The E-Sports Tourment Challenge/src/Query.java
+++ b/Year #2/First Half/CENG 211/The E-Sports Tourment Challenge/src/Query.java
@@ -158,9 +158,19 @@ public class Query {
 
         this.totalTournamentPoint = another.totalTournamentPoint;
 
-        this.highestScoringMatch = new Match (matches[0][0]);
-        this.lowestScoringMatch = new Match (matches[0][0]);
-        this.lowestBonusPointMatch = new Match (matches[0][0]);
+        if (another.highestScoringMatch == null) {
+            throw new IllegalArgumentException("Highest scoring match in source Query cannot be null");
+        }
+        if (another.lowestScoringMatch == null) {
+            throw new IllegalArgumentException("Lowest scoring match in source Query cannot be null");
+        }
+        if (another.lowestBonusPointMatch == null) {
+            throw new IllegalArgumentException("Lowest bonus point match in source Query cannot be null");
+        }
+
+        this.highestScoringMatch = new Match(another.highestScoringMatch);
+        this.lowestScoringMatch = new Match(another.lowestScoringMatch);
+        this.lowestBonusPointMatch = new Match(another.lowestBonusPointMatch);
     }
 
     /**


### PR DESCRIPTION
This pull request improves the robustness of the `Query` copy constructor in `Query.java` by adding null checks and better copying logic for match-related fields. Now, when copying from another `Query` object, the constructor will throw clear exceptions if any of the relevant match fields are null, and it will copy those fields directly from the source object instead of relying on the local `matches` array.

Improvements to object copying and error handling:

* Added null checks for `highestScoringMatch`, `lowestScoringMatch`, and `lowestBonusPointMatch` in the source `Query` object, throwing an `IllegalArgumentException` if any are null.
* Updated the copy logic to create new `Match` instances from the corresponding fields of the source `Query` object instead of always using `matches[0][0]`.