### PR TITLE
IOpenable.java added

### DIFF
--- a/Year #2/First Half/CENG 211/Box Top Side Matching Puzzle App/src/interfaces/IOpenable.java
+++ b/Year #2/First Half/CENG 211/Box Top Side Matching Puzzle App/src/interfaces/IOpenable.java
@@ -1,0 +1,56 @@
+package interfaces;
+
+import model.tools.SpecialTool;
+import core.exceptions.EmptyBoxException;
+
+/**
+ * Interface for boxes that can be opened to retrieve SpecialTools.
+ * All box types (RegularBox, UnchangingBox, FixedBox) can be opened,
+ * but only RegularBox and UnchangingBox may contain SpecialTools.
+ * FixedBox is always empty.
+ * 
+ * A box can only be opened if it was rolled during the current turn.
+ * Once opened, the box is marked as empty and cannot be opened again
+ * until it potentially gets a new tool (which doesn't happen in this game).
+ */
+public interface IOpenable {
+    
+    /**
+     * Opens the box and retrieves the SpecialTool inside.
+     * After opening, the box is marked as empty (the tool is removed).
+     * 
+     * @return the SpecialTool that was inside the box
+     * @throws EmptyBoxException if the box is empty
+     */
+    SpecialTool open() throws EmptyBoxException;
+    
+    /**
+     * Checks if the box is empty (no SpecialTool inside).
+     * 
+     * @return true if the box is empty, false otherwise
+     */
+    boolean isEmpty();
+    
+    /**
+     * Checks if the box has been opened during the current game.
+     * Used for display purposes (showing 'O' vs 'M' on the grid).
+     * 
+     * @return true if the box has been opened, false otherwise
+     */
+    boolean isOpened();
+    
+    /**
+     * Marks the box as having been rolled during the current turn.
+     * A box can only be opened if it was rolled in the same turn.
+     * 
+     * @param rolled true to mark as rolled, false to reset for next turn
+     */
+    void setRolledThisTurn(boolean rolled);
+    
+    /**
+     * Checks if the box was rolled during the current turn.
+     * 
+     * @return true if the box was rolled this turn, false otherwise
+     */
+    boolean wasRolledThisTurn();
+}


### PR DESCRIPTION
IOpenable is added instead of BoxOpener interface.
This pull request introduces a new interface, `IOpenable`, which standardizes how boxes in the puzzle game can be opened and interacted with. The interface defines the contract for opening boxes, checking their state, and managing their interaction within a turn.

New interface for box interactions:

* Added new `IOpenable` interface in `interfaces/IOpenable.java` to provide a unified way for all box types (`RegularBox`, `UnchangingBox`, `FixedBox`) to be opened, checked for contents, and managed per turn. The interface includes methods for opening a box, checking if it is empty or opened, and tracking whether it was rolled during the current turn.