### PR TITLE
IRollable.java added

### DIFF
--- a/Year #2/First Half/CENG 211/Box Top Side Matching Puzzle App/src/interfaces/IRollable.java
+++ b/Year #2/First Half/CENG 211/Box Top Side Matching Puzzle App/src/interfaces/IRollable.java
@@ -1,0 +1,36 @@
+package interfaces;
+
+import model.enums.Direction;
+import core.exceptions.UnmovableFixedBoxException;
+
+/**
+ * Interface for boxes that can be rolled in different directions.
+ * All Box types implement this interface through the Box abstract class.
+ * - RegularBox and UnchangingBox: Can roll normally
+ * - FixedBox: Implements the interface but overrides to throw UnmovableFixedBoxException
+ * 
+ * When a box rolls, its orientation changes:
+ * - Rolling RIGHT: right side becomes top, top becomes left, left becomes bottom, bottom becomes right
+ * - Rolling LEFT: left side becomes top, top becomes right, right becomes bottom, bottom becomes left
+ * - Rolling UP: front side becomes top, top becomes back, back becomes bottom, bottom becomes front
+ * - Rolling DOWN: back side becomes top, top becomes front, front becomes bottom, bottom becomes back
+ */
+public interface IRollable {
+    
+    /**
+     * Rolls the box in the specified direction.
+     * This changes which letter appears on the top side of the box.
+     * 
+     * @param direction the direction to roll the box
+     * @throws UnmovableFixedBoxException if attempting to roll a FixedBox
+     */
+    void roll(Direction direction) throws UnmovableFixedBoxException;
+    
+    /**
+     * Checks if this box can be rolled.
+     * Returns false for FixedBox, true for RegularBox and UnchangingBox.
+     * 
+     * @return true if the box can be rolled, false otherwise
+     */
+    boolean canRoll();
+}


### PR DESCRIPTION
IRollable interface is added instead of BoxOpener interface.
Assumed that the Direction is in model.enums.
This pull request introduces a new interface, `IRollable`, to define rollable behavior for box objects in the puzzle app. The interface standardizes how boxes are rolled and how their orientation changes, and it distinguishes between box types that can and cannot be rolled.

**Core functionality:**

* Added the `IRollable` interface in `interfaces/IRollable.java`, which specifies:
  - The `roll(Direction direction)` method for rolling a box, with clear documentation on how orientation changes for each direction and an exception for unmovable boxes.
  - The `canRoll()` method to indicate whether a box type can be rolled, supporting polymorphism for different box types.