### PR TITLE
3 Exceptions in homework are added.

### DIFF
--- a/Year #2/First Half/CENG 211/Box Top Side Matching Puzzle App/src/core/exceptions/BoxAlreadyFixedException.java
+++ b/Year #2/First Half/CENG 211/Box Top Side Matching Puzzle App/src/core/exceptions/BoxAlreadyFixedException.java
@@ -1,13 +1,53 @@
 package core.exceptions;
 
-public class BoxAlreadyFixedException extends RuntimeException {
-
+/**
+ * Exception thrown when attempting to use a BoxFixer tool on a box that is already fixed.
+ * 
+ * This exception occurs during the second stage of a turn when:
+ * - A player acquires a BoxFixer tool from an opened box
+ * - The player tries to use the BoxFixer on a box that is already a FixedBox
+ * - Attempting to fix a FixedBox is redundant and not allowed
+ * 
+ * When this exception is thrown, the turn is wasted and the game continues to the next turn.
+ * The application should catch and handle this exception gracefully without terminating.
+ * 
+ * Note: Using a BoxFixer on a RegularBox or UnchangingBox is valid - it replaces them
+ * with a FixedBox copy and removes any tool inside.
+ */
+public class BoxAlreadyFixedException extends Exception {
+    
+    /**
+     * Constructs a new BoxAlreadyFixedException with no detail message.
+     */
     public BoxAlreadyFixedException() {
         super();
     }
-
+    
+    /**
+     * Constructs a new BoxAlreadyFixedException with the specified detail message.
+     * 
+     * @param message the detail message explaining why the operation failed
+     */
     public BoxAlreadyFixedException(String message) {
-
         super(message);
+    }
+    
+    /**
+     * Constructs a new BoxAlreadyFixedException with the specified detail message and cause.
+     * 
+     * @param message the detail message
+     * @param cause the cause of this exception
+     */
+    public BoxAlreadyFixedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    
+    /**
+     * Constructs a new BoxAlreadyFixedException with the specified cause.
+     * 
+     * @param cause the cause of this exception
+     */
+    public BoxAlreadyFixedException(Throwable cause) {
+        super(cause);
     }
 }

--- a/Year #2/First Half/CENG 211/Box Top Side Matching Puzzle App/src/core/exceptions/EmptyBoxException.java
+++ b/Year #2/First Half/CENG 211/Box Top Side Matching Puzzle App/src/core/exceptions/EmptyBoxException.java
@@ -1,12 +1,51 @@
 package core.exceptions;
 
-public class EmptyBoxException extends RuntimeException {
-
-    public EmptyBoxException(){
+/**
+ * Exception thrown when attempting to open a box that is empty.
+ * 
+ * This exception occurs during the second stage of a turn when:
+ * - A player opens a box that contains no SpecialTool
+ * - The box was previously opened and its tool was already taken
+ * - A FixedBox is opened (always empty)
+ * - A RegularBox is opened and it was generated without a tool (25% chance)
+ * 
+ * When this exception is thrown, the turn is wasted and the game continues to the next turn.
+ * The application should catch and handle this exception gracefully without terminating.
+ */
+public class EmptyBoxException extends Exception {
+    
+    /**
+     * Constructs a new EmptyBoxException with no detail message.
+     */
+    public EmptyBoxException() {
         super();
     }
+    
+    /**
+     * Constructs a new EmptyBoxException with the specified detail message.
+     * 
+     * @param message the detail message explaining why the box is empty
+     */
     public EmptyBoxException(String message) {
-
         super(message);
+    }
+    
+    /**
+     * Constructs a new EmptyBoxException with the specified detail message and cause.
+     * 
+     * @param message the detail message
+     * @param cause the cause of this exception
+     */
+    public EmptyBoxException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    
+    /**
+     * Constructs a new EmptyBoxException with the specified cause.
+     * 
+     * @param cause the cause of this exception
+     */
+    public EmptyBoxException(Throwable cause) {
+        super(cause);
     }
 }

--- a/Year #2/First Half/CENG 211/Box Top Side Matching Puzzle App/src/core/exceptions/UnmovableFixedBoxException.java
+++ b/Year #2/First Half/CENG 211/Box Top Side Matching Puzzle App/src/core/exceptions/UnmovableFixedBoxException.java
@@ -1,12 +1,53 @@
 package core.exceptions;
 
+/**
+ * Exception thrown when attempting to move or manipulate a FixedBox in ways it cannot support.
+ * 
+ * This exception occurs when:
+ * - A player selects an edge FixedBox during the first stage of a turn (trying to roll it)
+ * - A BoxFlipper tool is used on a FixedBox (trying to flip it upside down)
+ * - Any operation tries to change the orientation of a FixedBox
+ * 
+ * FixedBoxes are immovable and their top side stays the same at all times.
+ * They also prevent the domino-effect from being transmitted past them.
+ * 
+ * When this exception is thrown, the turn is wasted and the game continues to the next turn.
+ * The application should catch and handle this exception gracefully without terminating.
+ */
 public class UnmovableFixedBoxException extends RuntimeException {
-
-    public UnmovableFixedBoxException(){
+    
+    /**
+     * Constructs a new UnmovableFixedBoxException with no detail message.
+     */
+    public UnmovableFixedBoxException() {
         super();
     }
+    
+    /**
+     * Constructs a new UnmovableFixedBoxException with the specified detail message.
+     * 
+     * @param message the detail message explaining why the FixedBox cannot be moved
+     */
     public UnmovableFixedBoxException(String message) {
-
         super(message);
+    }
+    
+    /**
+     * Constructs a new UnmovableFixedBoxException with the specified detail message and cause.
+     * 
+     * @param message the detail message
+     * @param cause the cause of this exception
+     */
+    public UnmovableFixedBoxException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    
+    /**
+     * Constructs a new UnmovableFixedBoxException with the specified cause.
+     * 
+     * @param cause the cause of this exception
+     */
+    public UnmovableFixedBoxException(Throwable cause) {
+        super(cause);
     }
 }


### PR DESCRIPTION
This pull request improves the exception handling for box-related errors in the Box Top Side Matching Puzzle App by enhancing the documentation, standardizing constructors, and making the exception types more appropriate for their use cases. The main changes involve adding detailed Javadoc comments, providing full constructor overloads, and switching some exceptions from unchecked to checked types for better error management.

**Exception class improvements:**

* Added detailed Javadoc comments to `BoxAlreadyFixedException`, `EmptyBoxException`, and `UnmovableFixedBoxException`, explaining when each exception is thrown and how it should be handled in the application. [[1]](diffhunk://#diff-f45985e89ef68a7f30873f1dce694d879cb54e58c9cd3345d2d3d3c53649d220L3-R52) [[2]](diffhunk://#diff-998358f89b03696d5b4521e40ce5bfe05bd543eb6d19c4dae7a7c8a7fc99640dL3-R50) [[3]](diffhunk://#diff-33eea9ecde93ccc7d7471892167478ae8d5bc0c731bc2c2db878624cd8cf7982R3-R52)
* Provided full sets of constructors (default, message, message+cause, cause) for all three exception classes, improving flexibility for exception creation and propagation. [[1]](diffhunk://#diff-f45985e89ef68a7f30873f1dce694d879cb54e58c9cd3345d2d3d3c53649d220L3-R52) [[2]](diffhunk://#diff-998358f89b03696d5b4521e40ce5bfe05bd543eb6d19c4dae7a7c8a7fc99640dL3-R50) [[3]](diffhunk://#diff-33eea9ecde93ccc7d7471892167478ae8d5bc0c731bc2c2db878624cd8cf7982R3-R52)

**Exception type adjustments:**

* Changed `BoxAlreadyFixedException` and `EmptyBoxException` from extending `RuntimeException` (unchecked) to extending `Exception` (checked), enforcing explicit handling of these errors in the application logic. [[1]](diffhunk://#diff-f45985e89ef68a7f30873f1dce694d879cb54e58c9cd3345d2d3d3c53649d220L3-R52) [[2]](diffhunk://#diff-998358f89b03696d5b4521e40ce5bfe05bd543eb6d19c4dae7a7c8a7fc99640dL3-R50)
* Retained `UnmovableFixedBoxException` as a `RuntimeException`, but added full documentation and constructors for consistency.