### PR TITLE
FixedBox.java is added.

### DIFF
--- a/Year #2/First Half/CENG 211/Box Top Side Matching Puzzle App/src/model/box/FixedBox.java
+++ b/Year #2/First Half/CENG 211/Box Top Side Matching Puzzle App/src/model/box/FixedBox.java
@@ -1,4 +1,112 @@
 package model.box;
 
-public class FixedBox {
+import model.enums.Letter;
+import model.enums.Direction;
+import core.exceptions.UnmovableFixedBoxException;
+
+/**
+ * FixedBox is a special box that cannot be rolled or stamped.
+ * 
+ * Generation probability: 5%
+ * Tool probability: 0% (always empty)
+ * 
+ * Characteristics:
+ * - CANNOT be rolled - throws UnmovableFixedBoxException when attempting to roll
+ * - Can be opened but is always empty (inherits from Box via IOpenable)
+ * - Does NOT implement IStampable - cannot be stamped
+ * - Blocks the domino-effect from passing through it during rolling operations
+ * - Top side letter never changes throughout the game
+ * - Marked as empty from the start (containedTool is always null)
+ */
+public class FixedBox extends Box {
+    
+    /**
+     * Default constructor that creates a FixedBox with random surfaces.
+     * Always empty (no tool inside).
+     */
+    public FixedBox() {
+        super();
+    }
+    
+    /**
+     * Constructor that allows manual specification of all 6 surfaces.
+     * Always empty (no tool inside).
+     * 
+     * @param top the letter on the top surface
+     * @param bottom the letter on the bottom surface
+     * @param front the letter on the front surface
+     * @param back the letter on the back surface
+     * @param left the letter on the left surface
+     * @param right the letter on the right surface
+     */
+    public FixedBox(Letter top, Letter bottom, Letter front, Letter back, Letter left, Letter right) {
+        super(top, bottom, front, back, left, right);
+    }
+    
+    /**
+     * Initializes the tool content of the FixedBox.
+     * FixedBox is always empty - never contains a SpecialTool.
+     */
+    @Override
+    protected void initializeTool() {
+        containedTool = null;
+    }
+    
+    /**
+     * Overrides the roll method to prevent rolling (IRollable implementation).
+     * FixedBox cannot be rolled - always throws UnmovableFixedBoxException.
+     * 
+     * @param direction the direction to roll (ignored)
+     * @throws UnmovableFixedBoxException always thrown when attempting to roll a FixedBox
+     */
+    @Override
+    public void roll(Direction direction) throws UnmovableFixedBoxException {
+        throw new UnmovableFixedBoxException("FixedBox cannot be rolled!");
+    }
+    
+    /**
+     * Checks if this box can be rolled (IRollable implementation).
+     * FixedBox always returns false.
+     * 
+     * @return false (FixedBox cannot be rolled)
+     */
+    @Override
+    public boolean canRoll() {
+        return false;
+    }
+    
+    /**
+     * Overrides flipUpsideDown to prevent flipping.
+     * Attempting to flip a FixedBox should throw an exception.
+     * This method is called by BoxFlipper tool.
+     * 
+     * @throws UnmovableFixedBoxException when attempting to flip a FixedBox
+     */
+    @Override
+    public void flipUpsideDown() {
+        throw new UnmovableFixedBoxException("FixedBox cannot be flipped!");
+    }
+    
+    /**
+     * Returns the type identifier for FixedBox.
+     * 
+     * @return 'X' for FixedBox
+     */
+    @Override
+    public char getTypeIdentifier() {
+        return 'X';
+    }
+    
+    /**
+     * Returns a string representation of the FixedBox for grid display.
+     * Format: | X-LETTER-O |
+     * - STATUS is always 'O' (empty) since FixedBox never contains tools
+     * 
+     * @return formatted string for grid display
+     */
+    @Override
+    public String getGridDisplay() {
+        return String.format("| X-%c-O |", topSide.toChar());
+    }
 }
+


### PR DESCRIPTION
This pull request introduces the new `FixedBox` class, which represents a special type of box in the puzzle app that cannot be moved, rolled, or stamped, and is always empty. The class is thoroughly documented and overrides several methods from its superclass to enforce its unique behavior.

Key additions and overrides for the new `FixedBox` class:

**FixedBox behavior and constraints:**
* `FixedBox` extends `Box` and is always empty (never contains a tool), with its top side letter remaining constant throughout the game. (`[Year #2/First Half/CENG 211/Box Top Side Matching Puzzle App/src/model/box/FixedBox.javaL3-R112](diffhunk://#diff-10e2ce8b0d0140d7784a84db70ad220fc345625e30fde66a3720564febc148b2L3-R112)`)
* Rolling or flipping the box is prohibited; attempts to do so will throw an `UnmovableFixedBoxException`. (`[Year #2/First Half/CENG 211/Box Top Side Matching Puzzle App/src/model/box/FixedBox.javaL3-R112](diffhunk://#diff-10e2ce8b0d0140d7784a84db70ad220fc345625e30fde66a3720564febc148b2L3-R112)`)
* The class does not implement `IStampable`, so it cannot be stamped, and it blocks domino-effect rolling. (`[Year #2/First Half/CENG 211/Box Top Side Matching Puzzle App/src/model/box/FixedBox.javaL3-R112](diffhunk://#diff-10e2ce8b0d0140d7784a84db70ad220fc345625e30fde66a3720564febc148b2L3-R112)`)

**Method overrides and display:**
* Overrides `roll`, `canRoll`, and `flipUpsideDown` to enforce immovability, always returning false or throwing exceptions as appropriate. (`[Year #2/First Half/CENG 211/Box Top Side Matching Puzzle App/src/model/box/FixedBox.javaL3-R112](diffhunk://#diff-10e2ce8b0d0140d7784a84db70ad220fc345625e30fde66a3720564febc148b2L3-R112)`)
* Provides a specific type identifier (`'X'`) and a custom grid display string format for the UI. (`[Year #2/First Half/CENG 211/Box Top Side Matching Puzzle App/src/model/box/FixedBox.javaL3-R112](diffhunk://#diff-10e2ce8b0d0140d7784a84db70ad220fc345625e30fde66a3720564febc148b2L3-R112)`)